### PR TITLE
Reponse to Issue #187. bitvis_vip_gpio C_VVC_CMD_DATA_MAX_LENGTH has been increased to 1024.

### DIFF
--- a/bitvis_vip_gpio/src/transaction_pkg.vhd
+++ b/bitvis_vip_gpio/src/transaction_pkg.vhd
@@ -46,7 +46,7 @@ package transaction_pkg is
   );
 
   constant C_VVC_CMD_STRING_MAX_LENGTH : natural := 300;
-  constant C_VVC_CMD_DATA_MAX_LENGTH   : natural := 32;
+  constant C_VVC_CMD_DATA_MAX_LENGTH   : natural := 1024;
 
   --==========================================================================================
   --

--- a/bitvis_vip_gpio/tb/maintenance_tb/gpio_vip_tb.vhd
+++ b/bitvis_vip_gpio/tb/maintenance_tb/gpio_vip_tb.vhd
@@ -41,7 +41,6 @@ architecture func of gpio_vip_tb is
 
   constant C_CLK_PERIOD        : time    := 10 ns;
   constant C_SCOPE             : string  := C_TB_SCOPE_DEFAULT;
-  -- constant C_GPIO_WIDTH        : natural := 8;
   constant C_GPIO_SET_MAX_TIME : time    := 1 ps;
 
   signal gpio_1_input  : std_logic_vector(0 downto 0);
@@ -54,12 +53,7 @@ architecture func of gpio_vip_tb is
   signal gpio_7_output : std_logic_vector(7 downto 0);
   signal gpio_8_output : std_logic_vector(1023 downto 0);
   
-  -- signal gpio_9_inout  : std_logic_vector(0 downto 0);
   signal gpio_9_inout  : std_logic_vector(7 downto 0);
-  -- signal gpio_10_inout : std_logic_vector(1 downto 0);
-  -- signal gpio_11_inout : std_logic_vector(7 downto 0);
-  -- signal gpio_12_inout : std_logic_vector(1023 downto 0);
-  -- signal gpio_3_inout  : std_logic_vector(7 downto 0);  -- Temp
 
   procedure set_gpio(
     signal   pins   : out std_logic_vector;

--- a/bitvis_vip_gpio/tb/maintenance_tb/gpio_vip_tb.vhd
+++ b/bitvis_vip_gpio/tb/maintenance_tb/gpio_vip_tb.vhd
@@ -41,12 +41,25 @@ architecture func of gpio_vip_tb is
 
   constant C_CLK_PERIOD        : time    := 10 ns;
   constant C_SCOPE             : string  := C_TB_SCOPE_DEFAULT;
-  constant C_GPIO_WIDTH        : natural := 8;
+  -- constant C_GPIO_WIDTH        : natural := 8;
   constant C_GPIO_SET_MAX_TIME : time    := 1 ps;
 
-  signal gpio_1_input  : std_logic_vector(C_GPIO_WIDTH - 1 downto 0);
-  signal gpio_2_output : std_logic_vector(C_GPIO_WIDTH - 1 downto 0);
-  signal gpio_3_inout  : std_logic_vector(C_GPIO_WIDTH - 1 downto 0);
+  signal gpio_1_input  : std_logic_vector(0 downto 0);
+  signal gpio_2_input  : std_logic_vector(1 downto 0);
+  signal gpio_3_input  : std_logic_vector(7 downto 0);
+  signal gpio_4_input  : std_logic_vector(1023 downto 0);
+  
+  signal gpio_5_output : std_logic_vector(0 downto 0);
+  signal gpio_6_output : std_logic_vector(1 downto 0);
+  signal gpio_7_output : std_logic_vector(7 downto 0);
+  signal gpio_8_output : std_logic_vector(1023 downto 0);
+  
+  -- signal gpio_9_inout  : std_logic_vector(0 downto 0);
+  signal gpio_9_inout  : std_logic_vector(7 downto 0);
+  -- signal gpio_10_inout : std_logic_vector(1 downto 0);
+  -- signal gpio_11_inout : std_logic_vector(7 downto 0);
+  -- signal gpio_12_inout : std_logic_vector(1023 downto 0);
+  -- signal gpio_3_inout  : std_logic_vector(7 downto 0);  -- Temp
 
   procedure set_gpio(
     signal   pins   : out std_logic_vector;
@@ -72,34 +85,104 @@ begin
   -- GPIO as input
   i1_gpio_vvc : entity work.gpio_vvc
     generic map(
-      GC_DATA_WIDTH         => C_GPIO_WIDTH,
+      GC_DATA_WIDTH         => 1,
       GC_INSTANCE_IDX       => 1,
-      GC_DEFAULT_LINE_VALUE => x"ZZ"
+      GC_DEFAULT_LINE_VALUE => "Z"
     )
     port map(
       gpio_vvc_if => gpio_1_input
     );
-
-  -- GPIO as output
+    
+  -- GPIO as input
   i2_gpio_vvc : entity work.gpio_vvc
     generic map(
-      GC_DATA_WIDTH         => C_GPIO_WIDTH,
+      GC_DATA_WIDTH         => 2,
       GC_INSTANCE_IDX       => 2,
-      GC_DEFAULT_LINE_VALUE => x"00"
+      GC_DEFAULT_LINE_VALUE => "ZZ"
     )
     port map(
-      gpio_vvc_if => gpio_2_output
+      gpio_vvc_if => gpio_2_input
     );
-
-  -- GPIO as input/output
+    
+  -- GPIO as input
   i3_gpio_vvc : entity work.gpio_vvc
     generic map(
-      GC_DATA_WIDTH         => C_GPIO_WIDTH,
+      GC_DATA_WIDTH         => 8,
       GC_INSTANCE_IDX       => 3,
       GC_DEFAULT_LINE_VALUE => x"ZZ"
     )
     port map(
-      gpio_vvc_if => gpio_3_inout
+      gpio_vvc_if => gpio_3_input
+    );
+
+  -- GPIO as input
+  i4_gpio_vvc : entity work.gpio_vvc
+    generic map(
+      GC_DATA_WIDTH         => 1024,
+      GC_INSTANCE_IDX       => 4,
+      GC_DEFAULT_LINE_VALUE => (others => 'Z')
+    )
+    port map(
+      gpio_vvc_if => gpio_4_input
+    );
+    
+  ---------------------------------------------------------------
+
+  -- GPIO as output
+  i5_gpio_vvc : entity work.gpio_vvc
+    generic map(
+      GC_DATA_WIDTH         => 1,
+      GC_INSTANCE_IDX       => 5,
+      GC_DEFAULT_LINE_VALUE => "0"
+    )
+    port map(
+      gpio_vvc_if => gpio_5_output
+    );
+    
+  -- GPIO as output
+  i6_gpio_vvc : entity work.gpio_vvc
+    generic map(
+      GC_DATA_WIDTH         => 2,
+      GC_INSTANCE_IDX       => 6,
+      GC_DEFAULT_LINE_VALUE => "00"
+    )
+    port map(
+      gpio_vvc_if => gpio_6_output
+    );
+
+  -- GPIO as output
+  i7_gpio_vvc : entity work.gpio_vvc
+    generic map(
+      GC_DATA_WIDTH         => 8,
+      GC_INSTANCE_IDX       => 7,
+      GC_DEFAULT_LINE_VALUE => x"00"
+    )
+    port map(
+      gpio_vvc_if => gpio_7_output
+    );
+
+  -- GPIO as output
+  i8_gpio_vvc : entity work.gpio_vvc
+    generic map(
+      GC_DATA_WIDTH         => 1024,
+      GC_INSTANCE_IDX       => 8,
+      GC_DEFAULT_LINE_VALUE => (others => '0')
+    )
+    port map(
+      gpio_vvc_if => gpio_8_output
+    );
+    
+  ---------------------------------------------------------------   
+
+  -- GPIO as input/output
+  i9_gpio_vvc : entity work.gpio_vvc
+    generic map(
+      GC_DATA_WIDTH         => 8,
+      GC_INSTANCE_IDX       => 9,
+      GC_DEFAULT_LINE_VALUE => x"ZZ"
+    )
+    port map(
+      gpio_vvc_if => gpio_9_inout
     );
 
   ------------------------------------------------
@@ -110,9 +193,118 @@ begin
     variable v_received_data : bitvis_vip_gpio.vvc_cmd_pkg.t_vvc_result;
     variable v_set_data      : std_logic_vector(7 downto 0);
     variable v_expect_data   : std_logic_vector(7 downto 0);
+    variable v_data_1024     : std_logic_vector(1023 downto 0);
+    variable v_data_exp_1024 : std_logic_vector(1023 downto 0);
     variable v_vvc_id        : natural;
     variable v_cmd_idx       : natural;
     variable v_is_ok         : boolean;
+    
+    -- Procedure / Functions
+      
+    ----------------------------------------------------------------------
+    -- Test GPIO VVC Set method
+    ----------------------------------------------------------------------
+    procedure set_and_check_gpio(
+      constant vvc_instance_idx : natural;
+      signal   vvc_output       : std_logic_vector;
+      constant data             : std_logic_vector;
+      constant expected_data    : std_logic_vector
+      ) is
+    begin
+      -- Set GPIO setting to 0xAA. Check GPIO setting
+      gpio_set(GPIO_VVCT, vvc_instance_idx, data, "Setting gpio " & to_string(vvc_instance_idx) & " to 0x" & to_string(data, HEX) & ").");
+      await_completion(GPIO_VVCT, vvc_instance_idx, C_GPIO_SET_MAX_TIME);
+      check_value(vvc_output, expected_data, error, "Checking value of GPIO VVC " & to_string(vvc_instance_idx));
+      wait for C_CLK_PERIOD * 4;              -- Margin
+    end procedure set_and_check_gpio;
+   
+    ----------------------------------------------------------------------
+    -- Test of GPIO VVC Get method
+    ----------------------------------------------------------------------
+    procedure get_and_check_gpio(
+      constant vvc_instance_idx : natural;
+      signal   vvc_input        : out std_logic_vector;
+      constant data             : std_logic_vector
+      ) is
+      variable v_cmd_idx        : natural;
+      variable v_received_data  : bitvis_vip_gpio.vvc_cmd_pkg.t_vvc_result;
+      variable v_is_ok          : boolean;
+    begin
+      log("Testing get on GPIO VVC " & to_string(vvc_instance_idx));
+      set_gpio(vvc_input, data, "GPIO " & to_string(vvc_instance_idx) & " input");
+      -- Perform get, which stores the data in the VVC
+      gpio_get(GPIO_VVCT, vvc_instance_idx, "Readback inside VVC");
+      v_cmd_idx := get_last_received_cmd_idx(GPIO_VVCT, vvc_instance_idx);  -- for last get
+      await_completion(GPIO_VVCT, vvc_instance_idx, v_cmd_idx, 100 ns, "Wait for gpio_get to finish");
+      -- Fetch the result from index v_cmd_idx (last index set above)
+      fetch_result(GPIO_VVCT, vvc_instance_idx, v_cmd_idx, v_received_data, v_is_ok, "Fetching get-result");
+
+      -- Check if get was OK and that data is correct
+      check_value(v_is_ok, error,"Readback OK via fetch_result()");
+      check_value(v_received_data, data, error, "Readback data via fetch_result()");
+      wait for C_CLK_PERIOD * 4;    -- margin
+    end procedure get_and_check_gpio;
+    
+    ----------------------------------------------------------------------
+    -- Test of GPIO VVC Get method using Scoreboard to check received data
+    ----------------------------------------------------------------------
+    procedure get_and_check_gpio_sb(
+      constant vvc_instance_idx : natural;
+      signal   vvc_input        : out std_logic_vector;
+      constant data             : std_logic_vector
+      ) is
+      variable v_cmd_idx        : natural;
+    begin
+      log("Testing get on GPIO VVC " & to_string(vvc_instance_idx) & " using SB");
+      set_gpio(vvc_input, data, "GPIO " & to_string(vvc_instance_idx) & " input");
+      GPIO_VVC_SB.add_expected(vvc_instance_idx, pad_gpio_sb(data));
+      
+      -- Perform get, which stores the data in the VVC's Scoreboard
+      gpio_get(GPIO_VVCT, vvc_instance_idx, TO_SB, "Readback inside VVC using SB");
+      v_cmd_idx := get_last_received_cmd_idx(GPIO_VVCT, vvc_instance_idx);  -- for last get
+      await_completion(GPIO_VVCT, vvc_instance_idx, v_cmd_idx, 100 ns, "Wait for gpio_get to finish");
+      wait for C_CLK_PERIOD * 4;          -- Margin
+    end procedure get_and_check_gpio_sb;
+    
+    ----------------------------------------------------------------------
+    -- Test of GPIO VVC Check method
+    ----------------------------------------------------------------------
+    procedure check_gpio(
+      constant vvc_instance_idx : natural;
+      signal   vvc_input        : out std_logic_vector;
+      constant data             : std_logic_vector
+      ) is
+    begin
+      log("Testing check on GPIO VVC " & to_string(vvc_instance_idx));
+      set_gpio(vvc_input, data, "GPIO " & to_string(vvc_instance_idx) & " input");
+      wait for C_CLK_PERIOD;
+      
+      -- Perform get, which stores the data in the VVC
+      gpio_check(GPIO_VVCT, vvc_instance_idx, data, "Readback inside VVC", error);
+      await_completion(GPIO_VVCT, vvc_instance_idx, 100 ns, "Wait for gpio_check to finish");
+      wait for C_CLK_PERIOD * 4;
+    end procedure check_gpio;
+    
+    ----------------------------------------------------------------------
+    -- Test of GPIO VVC Check Stable method
+      -- Set GPIO input and call GPIO Check Stable and check actual GPIO
+      -- setting is same as expected and that it has been stable for a certain time.
+    ----------------------------------------------------------------------
+    procedure check_stable_gpio(
+      constant vvc_instance_idx : natural;
+      signal   vvc_input        : out std_logic_vector;
+      constant data             : std_logic_vector
+      ) is
+    begin
+      log("Testing check_stable on GPIO VVC " & to_string(vvc_instance_idx));
+      v_set_data    := x"77";
+      v_expect_data := v_set_data;
+      set_gpio(vvc_input, data, "GPIO " & to_string(vvc_instance_idx) & " input");
+      wait for C_CLK_PERIOD * 5;
+      -- Perform get, which stores the data in the VVC
+      gpio_check_stable(GPIO_VVCT, vvc_instance_idx, data, C_CLK_PERIOD * 5, "Readback inside VVC", error);
+      await_completion(GPIO_VVCT, vvc_instance_idx, 1 us, "Wait for gpio_check_stable to finish");
+    end procedure check_stable_gpio;
 
   begin
     -- To avoid that log files from different test cases (run in separate
@@ -129,374 +321,273 @@ begin
     report_global_ctrl(VOID);
     report_msg_id_panel(VOID);
 
-    disable_log_msg(ALL_MESSAGES);
+    -- disable_log_msg(ALL_MESSAGES);
+    enable_log_msg(ALL_MESSAGES);
     enable_log_msg(ID_SEQUENCER);
     enable_log_msg(ID_LOG_HDR);
     enable_log_msg(ID_BFM);
 
-    disable_log_msg(GPIO_VVCT, 1, ALL_MESSAGES);
-    enable_log_msg(GPIO_VVCT, 1, ID_BFM);
+    for i in 1 to 9 loop
+      disable_log_msg(GPIO_VVCT, i, ALL_MESSAGES);
+      enable_log_msg(GPIO_VVCT, i, ID_BFM);
+    end loop;
 
-    disable_log_msg(GPIO_VVCT, 2, ALL_MESSAGES);
-    enable_log_msg(GPIO_VVCT, 2, ID_BFM);
-
-    disable_log_msg(GPIO_VVCT, 3, ALL_MESSAGES);
-    enable_log_msg(GPIO_VVCT, 3, ID_BFM);
 
     log(ID_LOG_HDR, "Verifying TLM + GPIO executor + BFM", C_SCOPE);
     wait for C_CLK_PERIOD * 10;
     ------------------------------------------------------------
 
     --------------------------------------------------------------------------------------
-    --
     -- Checking of initial state
-    --
     --------------------------------------------------------------------------------------
-    log(ID_LOG_HDR, "Checking initial state of output VVC", C_SCOPE);
+    log(ID_LOG_HDR, "Checking initial state of output VVC's", C_SCOPE);
 
-    --
-    -- Check GPIO initial setting is 0x00
-    --
-    check_value(gpio_2_output, "00000000", error, "Checking initial value of GPIO VVC 2");
+    -- Check GPIO initial setting is all 0's
+    v_data_exp_1024 := (others => '0');
+    check_value(gpio_5_output, "0",           error, "Checking initial value of GPIO VVC 5");
+    check_value(gpio_6_output, "00",          error, "Checking initial value of GPIO VVC 6");
+    check_value(gpio_7_output, "00000000",    error, "Checking initial value of GPIO VVC 7");
+    check_value(gpio_8_output, v_data_exp_1024, error, "Checking initial value of GPIO VVC 8");
+
 
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC Set method
-    --
     --------------------------------------------------------------------------------------
     log(ID_LOG_HDR, "Test of GPIO Set", C_SCOPE);
 
-    --
-    -- Set GPIO setting to 0xAA. Check GPIO setting
-    --
-    v_set_data    := x"FF";             -- "1111 11111"
-    v_expect_data := v_set_data;
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-    wait for C_CLK_PERIOD;              -- Margin
+    -- Set GPIO  to all 1's. Check GPIO setting
+    v_data_1024 := (others => '1');
+    set_and_check_gpio(5, gpio_5_output, "1", "1");
+    set_and_check_gpio(6, gpio_6_output, "11", "11");
+    set_and_check_gpio(7, gpio_7_output, "11111111", "11111111");
+    set_and_check_gpio(8, gpio_8_output, v_data_1024, v_data_1024);
 
-    --
-    -- Set GPIO setting to 0xAA. Check GPIO setting
-    --
-    v_set_data    := x"AA";             -- "1010 1010"
-    v_expect_data := v_set_data;
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-    wait for C_CLK_PERIOD;              -- Margin
+    -- Set GPIO setting to 0xAA etc. Check GPIO setting
+    set_and_check_gpio(6, gpio_6_output, "01", "01");
+    set_and_check_gpio(7, gpio_7_output, "10101010", "10101010");
+    set_and_check_gpio(8, gpio_8_output, "10101010101", "10101010101");
+    
+    -- Set GPIO setting to all 0's. Check GPIO setting
+    set_and_check_gpio(5, gpio_5_output, "0", "0");
+    set_and_check_gpio(6, gpio_6_output, "00", "00");
+    set_and_check_gpio(7, gpio_7_output, "00000000", "00000000");
+    set_and_check_gpio(8, gpio_8_output, "00000000000", "00000000000");
+    
+    -- Set GPIO setting to all 1's. Check GPIO setting
+    set_and_check_gpio(5, gpio_5_output, "1", "1");
+    set_and_check_gpio(6, gpio_6_output, "11", "11");
+    set_and_check_gpio(7, gpio_7_output, "11111111", "11111111");
+    set_and_check_gpio(8, gpio_8_output, "11111111111", "11111111111");
 
-    --
-    -- Set GPIO setting to 0x00. Check GPIO setting
-    --
-    v_set_data    := x"00";             -- "0000 0000"
-    v_expect_data := v_set_data;
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-    wait for C_CLK_PERIOD * 4;          -- Margin
-
-    --
-    -- Set GPIO setting to 0xFF. Check GPIO setting
-    --
-    v_set_data    := x"FF";             -- "1111 1111"
-    v_expect_data := v_set_data;
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-    wait for C_CLK_PERIOD * 4;          -- Margin
 
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC Set method with don't care
-    --
     --------------------------------------------------------------------------------------
     log(ID_LOG_HDR, "Test of GPIO Set with don't care", C_SCOPE);
 
-    --
-    -- GPIO status is 0xFF. Test by setting bit 4-7, don't touch bit 0-3
-    --
-    v_set_data    := x"5-";             -- "0101 ----", should now be 0x5F
-    v_expect_data := x"5F";
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
+    -- GPIO status is all 1's. Test by setting bits to don't care with '-'
+    set_and_check_gpio(5, gpio_5_output, "-", "1");
+    set_and_check_gpio(6, gpio_6_output, "1-", "11");
+    set_and_check_gpio(7, gpio_7_output, "0101----", "01011111");
+    set_and_check_gpio(8, gpio_8_output, "010--------", "01011111111");
+    
+    set_and_check_gpio(5, gpio_5_output, "0", "0");
+    set_and_check_gpio(6, gpio_6_output, "-0", "10");
+    set_and_check_gpio(7, gpio_7_output, "----1010", "01011010");
+    set_and_check_gpio(8, gpio_8_output, "---10101010", "01010101010");
+    
+    set_and_check_gpio(5, gpio_5_output, "1", "-"); --?
+    set_and_check_gpio(6, gpio_6_output, "01", "-1");
+    set_and_check_gpio(7, gpio_7_output, "01010101", "---1---1");
+    set_and_check_gpio(8, gpio_8_output, "10101010101", "--1---1---1");
 
-    --
-    -- GPIO setting is 0x5F. Test by setting bit 0-3, don't touch bit 4-7
-    --
-    v_set_data    := x"-A";             -- "---- 1010", should now be 0x5A
-    v_expect_data := x"5A";
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-    wait for C_CLK_PERIOD * 4;          -- Margin
+    set_and_check_gpio(6, gpio_6_output, "1-", "-1");
+    set_and_check_gpio(7, gpio_7_output, "101-101-", "---1---1");
+    set_and_check_gpio(8, gpio_8_output, "01-101-101-", "--1---1---1");
+    
+    set_and_check_gpio(5, gpio_5_output, "Z", "-"); --?
+    set_and_check_gpio(6, gpio_6_output, "1Z", "1-");
+    set_and_check_gpio(7, gpio_7_output, "1010ZZZZ", "1010----");
+    set_and_check_gpio(8, gpio_8_output, "101ZZZZZZZZ", "101--------");
 
-    --
-    -- Set GPIO setting to 0x55. Check bit 0 and bit 4, ignore bit 1-3 and 5-7
-    --
-    v_set_data    := "01010101";        -- 0x55
-    v_expect_data := "---1---1";
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-
-    --
-    -- Set GPIO bit 1-3 and bit 5-7. Change bit 1-3 and 5-7, check bit 0 and bit 4
-    --
-    v_set_data := "101-101-";
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-    wait for C_CLK_PERIOD;              -- Margin
-
-    --
-    -- Set GPIO setting to 0xAZ. Check bit 4-7 is A, ignore bit 0-3
-    --
-    v_set_data    := x"AZ";
-    v_expect_data := "1010----";
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting gpio 2 to 0x" & to_string(v_set_data, HEX) & " (" & to_string(v_set_data, BIN) & ").");
-    await_completion(GPIO_VVCT, 2, C_GPIO_SET_MAX_TIME);
-    check_value(gpio_2_output, v_expect_data, error, "Checking value of GPIO VVC 2");
-    wait for C_CLK_PERIOD;              -- Margin
 
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC Get method
-    --
     --------------------------------------------------------------------------------------
     log(ID_LOG_HDR, "Test of GPIO Get", C_SCOPE);
-
-    --
-    -- Set GPIO 1 input manually to 0x1D. Test GPIO Get method and check
-    -- received data from GPIO setting.
-    --
-    log("Testing get on GPIO VVC 1");
-    v_set_data    := x"1D";
-    v_expect_data := v_set_data;
-    set_gpio(gpio_1_input, v_set_data, "GPIO 1 input");
-    -- Perform get, which stores the data in the VVC
-    gpio_get(GPIO_VVCT, 1, "Readback inside VVC");
-    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 1); -- for last get
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_get to finish");
-    -- Fetch the result from index v_cmd_idx (last index set above)
-    fetch_result(GPIO_VVCT, 1, v_cmd_idx, v_received_data, v_is_ok, "Fetching get-result");
-    -- Check if get was OK and that the data is correct
-    check_value(v_is_ok, error, "Readback OK via fetch_result()");
-    check_value(v_received_data, v_expect_data, error, "Readback data via fetch_result()");
-    wait for C_CLK_PERIOD * 4;          -- Margin
-
-    --
+    v_data_exp_1024 := (others => '1');
+    get_and_check_gpio(1, gpio_1_input, "1");
+    get_and_check_gpio(2, gpio_2_input, "11");
+    get_and_check_gpio(3, gpio_3_input, "00011101");
+    get_and_check_gpio(4, gpio_4_input, v_data_exp_1024);
+    
+    
+    --------------------------------------------------------------------------------------
     -- Test GPIO Get method using Scoreboard to check received data.
-    --
-    log("Testing get on GPIO VVC 1 using SB");
-    v_set_data := x"5A";
-    set_gpio(gpio_1_input, v_set_data, "GPIO 1 input");
-    GPIO_VVC_SB.add_expected(1, pad_gpio_sb(v_set_data));
-    -- Perform get, which stores the data in the VVC's Scoreboard
-    gpio_get(GPIO_VVCT, 1, TO_SB, "Readback inside VVC using SB");
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_get to finish");
-    wait for C_CLK_PERIOD * 4;          -- Margin
-
-    log("Testing get on GPIO VVC 2 using SB");
-    v_set_data := x"B8";
-    gpio_set(GPIO_VVCT, 2, v_set_data, "Setting GPIO 2 input.");
-    GPIO_VVC_SB.add_expected(2, pad_gpio_sb(v_set_data));
-    -- Perform get, which stores the data in the VVC's Scoreboard
-    gpio_get(GPIO_VVCT, 2, TO_SB, "Readback inside VVC using SB");
-    await_completion(GPIO_VVCT, 2, v_cmd_idx, 100 ns, "Wait for gpio_get to finish");
-    wait for C_CLK_PERIOD * 4;          -- Margin
+    --------------------------------------------------------------------------------------
+    v_data_exp_1024 := (others => '0');
+    get_and_check_gpio_sb(1, gpio_1_input, "0");
+    get_and_check_gpio_sb(2, gpio_2_input, "00");
+    get_and_check_gpio_sb(3, gpio_3_input, "11111111");
+    get_and_check_gpio_sb(4, gpio_4_input, v_data_exp_1024);
 
     GPIO_VVC_SB.report_counters(ALL_INSTANCES);
 
+
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC Check method
-    --
     --------------------------------------------------------------------------------------
     log(ID_LOG_HDR, "Test of GPIO Check", C_SCOPE);
+    v_data_exp_1024 := (others => '1');
+    check_gpio(1, gpio_1_input, "1");
+    check_gpio(2, gpio_2_input, "11");
+    check_gpio(3, gpio_3_input, "00000000");
+    check_gpio(4, gpio_4_input, v_data_exp_1024);
 
-    --
-    -- Set GPIO 1 input manually to 0x55. Call GPIO Check and check actual GPIO
-    -- setting with expected GPIO setting.
-    --
-    log("Testing check on GPIO VVC 1");
-    v_set_data    := x"55";
-    v_expect_data := v_set_data;
-    set_gpio(gpio_1_input, v_set_data, "GPIO 1 input");
-    wait for C_CLK_PERIOD;
-    -- Perform get, which stores the data in the VVC
-    gpio_check(GPIO_VVCT, 1, v_expect_data, "Readback inside VVC", error);
-    wait for C_CLK_PERIOD * 4;
 
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC Check Stable method
-    --
     --------------------------------------------------------------------------------------
-    log(ID_LOG_HDR, "Test of GPIO Check Stable", C_SCOPE);
+    v_data_exp_1024 := (others => '0');
+    check_stable_gpio(1, gpio_1_input, "0");
+    check_stable_gpio(2, gpio_2_input, "00");
+    check_stable_gpio(3, gpio_3_input, "11111111");
+    check_stable_gpio(4, gpio_4_input, v_data_exp_1024);
 
-    --
-    -- Set GPIO 1 input to 0x77. Call GPIO Check Stable and check actual GPIO
-    -- setting is same as expected and that it has been stable for a certain time.
-    --
-    log("Testing check_stable on GPIO VVC 1");
-    v_set_data    := x"77";
-    v_expect_data := v_set_data;
-    set_gpio(gpio_1_input, v_set_data, "GPIO 1 input");
-    wait for C_CLK_PERIOD * 5;
-    -- Perform get, which stores the data in the VVC
-    gpio_check_stable(GPIO_VVCT, 1, v_expect_data, C_CLK_PERIOD * 5, "Readback inside VVC", error);
-    await_completion(GPIO_VVCT, 1, 1 us, "Wait for gpio_check_stable to finish");
 
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC Expect method
-    --
     --------------------------------------------------------------------------------------
     log(ID_LOG_HDR, "Test of GPIO Expect", C_SCOPE);
 
-    --
     -- Set GPIO setting to 0xFF. Test GPIO Expect and that GPIO setting is
     -- updated immediately (within 0 ns).
-    --
     log("Testing gpio_expect as instant change check");
     v_set_data    := x"FF";
     v_expect_data := v_set_data;
-    set_gpio(gpio_1_input, v_set_data, "Setting GPIO 1 input to 0xff");
-    gpio_expect(GPIO_VVCT, 1, v_expect_data, 0 ns, "Checking GPIO 1", error);
-    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 1); -- for last get
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
+    set_gpio(gpio_3_input, v_set_data, "Setting GPIO 3 input to 0xff");
+    gpio_expect(GPIO_VVCT, 3, v_expect_data, 0 ns, "Checking GPIO 3", error);
+    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
+    await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
 
-    --
     -- Set GPIO setting to 0xFF, then to 0x12 after 90 ns. Test GPIO Expect
     -- with delay by checking that GPIO setting is set to 0x12 after 100 ns.
-    --
     log("Testing gpio_expect where value is correct after a delay");
     v_set_data    := x"FF";
     v_expect_data := x"12";
-    set_gpio(gpio_1_input, v_set_data, "Setting GPIO 1 input to 0xff");
+    set_gpio(gpio_3_input, v_set_data, "Setting GPIO 3 input to 0xff");
     wait for C_CLK_PERIOD;
-    gpio_expect(GPIO_VVCT, 1, v_expect_data, 100 ns, "Checking GPIO 1", error);
+    gpio_expect(GPIO_VVCT, 3, v_expect_data, 100 ns, "Checking GPIO 3", error);
     wait for 80 ns;
     v_set_data    := x"12";
-    set_gpio(gpio_1_input, v_set_data, "Setting GPIO 1 input to 0x12");
-    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 1); -- for last get
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
+    set_gpio(gpio_3_input, v_set_data, "Setting GPIO 3 input to 0x12");
+    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
+    await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
 
-    --
     -- Set GPIO setting to 0xFF, 0xAA, 0xAB, 0xAC and finally 0x00. Test GPIO
     -- Expect by checking that GPIO setting is set to 0x00 after 10 clk periods.
-    --
     log("Testing gpio_expect where value is not first to arrive");
     v_set_data    := x"FF";
     v_expect_data := x"00";
-    set_gpio(gpio_1_input, v_set_data, "Setting GPIO 1 input to 0xff");
+    set_gpio(gpio_3_input, v_set_data, "Setting GPIO 3 input to 0xff");
     wait for C_CLK_PERIOD;
-    gpio_expect(GPIO_VVCT, 1, v_expect_data, C_CLK_PERIOD * 10, "Checking GPIO 1", error);
+    gpio_expect(GPIO_VVCT, 3, v_expect_data, C_CLK_PERIOD * 10, "Checking GPIO 3", error);
     wait for C_CLK_PERIOD;
-    set_gpio(gpio_1_input, x"aa", "Setting GPIO 1 input to 0xaa");
-    set_gpio(gpio_1_input, x"ab", "Setting GPIO 1 input to 0xab");
-    set_gpio(gpio_1_input, x"ac", "Setting GPIO 1 input to 0xac");
-    set_gpio(gpio_1_input, x"00", "Setting GPIO 1 input to 0x00");
-    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 1); -- for last get
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
+    set_gpio(gpio_3_input, x"aa", "Setting GPIO 3 input to 0xaa");
+    set_gpio(gpio_3_input, x"ab", "Setting GPIO 3 input to 0xab");
+    set_gpio(gpio_3_input, x"ac", "Setting GPIO 3 input to 0xac");
+    set_gpio(gpio_3_input, x"00", "Setting GPIO 3 input to 0x00");
+    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
+    await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
+
 
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC Expect Stable method
-    --
     --------------------------------------------------------------------------------------
     log(ID_LOG_HDR, "Test of GPIO Expect Stable", C_SCOPE);
-    --
-    -- Set GPIO 1 input to 0xAA. Call GPIO Expect Stable and check actual GPIO
+
+    -- Set GPIO 3 input to 0xAA. Call GPIO Expect Stable and check actual GPIO
     -- setting is same as expected and that it remains stable for a certain time.
-    --
     log("Testing gpio_expect_stable with expected stable value FROM_NOW");
     v_set_data    := x"AA";
     v_expect_data := v_set_data;
-    set_gpio(gpio_1_input, v_set_data, "Setting GPIO 1 input to 0xAA");
-    gpio_expect_stable(GPIO_VVCT, 1, v_expect_data, C_CLK_PERIOD * 5, FROM_NOW, 0 ns, "Checking GPIO 1", error);
-    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 1); -- for last get
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_expect_stable to finish");
+    set_gpio(gpio_3_input, v_set_data, "Setting GPIO 3 input to 0xAA");
+    gpio_expect_stable(GPIO_VVCT, 3, v_expect_data, C_CLK_PERIOD * 5, FROM_NOW, 0 ns, "Checking GPIO 3", error);
+    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
+    await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect_stable to finish");
 
-    --
-    -- Set GPIO 1 input to 0xBB and wait. Call GPIO Expect Stable and check actual GPIO
+    -- Set GPIO 3 input to 0xBB and wait. Call GPIO Expect Stable and check actual GPIO
     -- setting is same as expected and that it has been stable for a certain time after
     -- the last event.
-    --
     log("Testing gpio_expect_stable with expected stable value FROM_LAST_EVENT");
     v_set_data    := x"BB";
     v_expect_data := v_set_data;
-    set_gpio(gpio_1_input, v_set_data, "Setting GPIO 1 input to 0xBB");
+    set_gpio(gpio_3_input, v_set_data, "Setting GPIO 3 input to 0xBB");
     wait for C_CLK_PERIOD * 5;
-    gpio_expect_stable(GPIO_VVCT, 1, v_expect_data, C_CLK_PERIOD * 10, FROM_LAST_EVENT, 0 ns, "Checking GPIO 1", error);
-    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 1); -- for last get
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_expect_stable to finish");
+    gpio_expect_stable(GPIO_VVCT, 3, v_expect_data, C_CLK_PERIOD * 10, FROM_LAST_EVENT, 0 ns, "Checking GPIO 3", error);
+    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
+    await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect_stable to finish");
 
-    --
-    -- Set GPIO 1 input to 0xCC after 10 ns. Call GPIO Expect Stable and wait until actual GPIO
+    -- Set GPIO 3 input to 0xCC after 10 ns. Call GPIO Expect Stable and wait until actual GPIO
     -- setting is same as expected and that it remains stable for a certain time.
-    --
     log("Testing gpio_expect_stable with expected stable value after a delayed update");
     v_set_data    := x"CC";
     v_expect_data := v_set_data;
-    gpio_expect_stable(GPIO_VVCT, 1, v_expect_data, C_CLK_PERIOD * 5, FROM_NOW, 20 ns, "Checking GPIO 1", error);
+    gpio_expect_stable(GPIO_VVCT, 3, v_expect_data, C_CLK_PERIOD * 5, FROM_NOW, 20 ns, "Checking GPIO 3", error);
     wait for 10 ns;
-    set_gpio(gpio_1_input, v_set_data, "Setting GPIO 1 input to 0xCC");
-    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 1); -- for last get
-    await_completion(GPIO_VVCT, 1, v_cmd_idx, 100 ns, "Wait for gpio_expect_stable to finish");
+    set_gpio(gpio_3_input, v_set_data, "Setting GPIO 3 input to 0xCC");
+    v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
+    await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect_stable to finish");
+
 
     --------------------------------------------------------------------------------------
-    --
     -- Test of GPIO VVC as inout port
-    --
     --------------------------------------------------------------------------------------
     log(ID_LOG_HDR, "Test of GPIO VVC as inout port", C_SCOPE);
 
     for i in 0 to 1 loop
-      log("GPIO 3 port is 'Z', set data using the DUT to configure as input");
+      log("GPIO 9 port is 'Z', set data using the DUT to configure as input");
       v_set_data    := x"55";
       v_expect_data := v_set_data;
-      set_gpio(gpio_3_inout, v_set_data, "Setting GPIO 3 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
-      gpio_expect(GPIO_VVCT, 3, v_expect_data, 0 ns, "Checking GPIO 3", error);
-      v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
-      await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
+      set_gpio(gpio_9_inout, v_set_data, "Setting GPIO 9 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
+      gpio_expect(GPIO_VVCT, 9, v_expect_data, 0 ns, "Checking GPIO 9", error);
+      v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 9); -- for last get
+      await_completion(GPIO_VVCT, 9, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
       wait for C_CLK_PERIOD;
 
       v_set_data    := x"AA";
       v_expect_data := v_set_data;
-      set_gpio(gpio_3_inout, v_set_data, "Setting GPIO 3 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
-      gpio_expect(GPIO_VVCT, 3, v_expect_data, 0 ns, "Checking GPIO 3", error);
-      v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 3); -- for last get
-      await_completion(GPIO_VVCT, 3, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
+      set_gpio(gpio_9_inout, v_set_data, "Setting GPIO 9 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
+      gpio_expect(GPIO_VVCT, 9, v_expect_data, 0 ns, "Checking GPIO 9", error);
+      v_cmd_idx     := get_last_received_cmd_idx(GPIO_VVCT, 9); -- for last get
+      await_completion(GPIO_VVCT, 9, v_cmd_idx, 100 ns, "Wait for gpio_expect to finish");
       wait for C_CLK_PERIOD;
 
-      log("Set GPIO 3 port to 'Z' from the DUT to release the port");
+      log("Set GPIO 9 port to 'Z' from the DUT to release the port");
       v_set_data := x"ZZ";
-      set_gpio(gpio_3_inout, v_set_data, "Releasing the port");
-      await_completion(GPIO_VVCT, 3, C_GPIO_SET_MAX_TIME);
+      set_gpio(gpio_9_inout, v_set_data, "Releasing the port");
+      await_completion(GPIO_VVCT, 9, C_GPIO_SET_MAX_TIME);
       wait for C_CLK_PERIOD;
 
-      log("GPIO 3 port is 'Z', set data using the VVC to configure as output");
+      log("GPIO 9 port is 'Z', set data using the VVC to configure as output");
       v_set_data    := x"FF";
       v_expect_data := v_set_data;
-      gpio_set(GPIO_VVCT, 3, v_set_data, "Setting GPIO 3 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
-      await_completion(GPIO_VVCT, 3, C_GPIO_SET_MAX_TIME);
-      check_value(gpio_3_inout, v_expect_data, error, "Checking value of GPIO VVC 3");
+      gpio_set(GPIO_VVCT, 9, v_set_data, "Setting GPIO 9 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
+      await_completion(GPIO_VVCT, 9, C_GPIO_SET_MAX_TIME);
+      check_value(gpio_9_inout, v_expect_data, error, "Checking value of GPIO VVC 9");
       wait for C_CLK_PERIOD;
 
       v_set_data    := x"33";
       v_expect_data := v_set_data;
-      gpio_set(GPIO_VVCT, 3, v_set_data, "Setting GPIO 3 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
-      await_completion(GPIO_VVCT, 3, C_GPIO_SET_MAX_TIME);
-      check_value(gpio_3_inout, v_expect_data, error, "Checking value of GPIO VVC 3");
+      gpio_set(GPIO_VVCT, 9, v_set_data, "Setting GPIO 9 input to " & to_string(v_set_data, HEX, KEEP_LEADING_0, INCL_RADIX));
+      await_completion(GPIO_VVCT, 9, C_GPIO_SET_MAX_TIME);
+      check_value(gpio_9_inout, v_expect_data, error, "Checking value of GPIO VVC 9");
       wait for C_CLK_PERIOD;
 
-      log("Set GPIO 3 port to 'Z' from the VVC to release the port");
+      log("Set GPIO 9 port to 'Z' from the VVC to release the port");
       v_set_data := x"ZZ";
-      gpio_set(GPIO_VVCT, 3, v_set_data, "Releasing the port");
-      await_completion(GPIO_VVCT, 3, C_GPIO_SET_MAX_TIME);
+      gpio_set(GPIO_VVCT, 9, v_set_data, "Releasing the port");
+      await_completion(GPIO_VVCT, 9, C_GPIO_SET_MAX_TIME);
       wait for C_CLK_PERIOD;
     end loop;
 

--- a/uvvm_util/src/adaptations_pkg.vhd
+++ b/uvvm_util/src/adaptations_pkg.vhd
@@ -287,7 +287,7 @@ package adaptations_pkg is
   constant C_RESULT_QUEUE_COUNT_MAX                : natural       := 20; -- (VVC Result queue)  May be overwritten for dedicated VVC
   constant C_RESULT_QUEUE_COUNT_THRESHOLD_SEVERITY : t_alert_level := WARNING;
   constant C_RESULT_QUEUE_COUNT_THRESHOLD          : natural       := 18;
-  constant C_MAX_VVC_INSTANCE_NUM                  : natural       := 8;
+  constant C_MAX_VVC_INSTANCE_NUM                  : natural       := 10;
   constant C_MAX_NUM_SEQUENCERS                    : natural       := 10; -- Max number of sequencers
   constant C_MAX_TB_VVC_NUM                        : natural       := 20; -- Max number of VVCs in testbench (including all channels)
 


### PR DESCRIPTION
Increased C_VVC_CMD_DATA_MAX_LENGTH of bitvis_vip_gpio C_VVC_CMD_DATA_MAX_LENGTH to 1024 as a response to the issue #187.
Also expanded the testbench to include multiple widths (1, 2, 8 and 1024).

The value of the 1024 vector may in some testcases be questionable.
The expect, expect_stable and inout testcases are left as is.

The uvvm_regression test runs without any errors with this change.